### PR TITLE
Fix CMakeLists to compile driver with Ros2 Humble

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
 )
 
-SET(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 
 file(GLOB  MAIN_SRC src/*.cpp)
 


### PR DESCRIPTION
Remove '-std=c++11' from CMakeLists.txt. Now driver can compile wih ROS2 Humble