### PR TITLE
Added libudev-dev dependency.

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
+  <depend>libudev-dev</depend>
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
The lack of this dependency prevented rosdep from installing all dependencies necessary for build.