### PR TITLE
Remove ament-lint-auto in build test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,6 @@ find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(Boost REQUIRED system)
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ################################################################################
 # Build


### PR DESCRIPTION
I removed the use of ament_lint_auto during the build test, as it caused errors when distributing the binary release.
```
15:07:46 CMake Error at CMakeLists.txt:29 (find_package):
15:07:46   By not providing "Findament_lint_auto.cmake" in CMAKE_MODULE_PATH this
15:07:46   project has asked CMake to find a package configuration file provided by
15:07:46   "ament_lint_auto", but CMake did not find one.
15:07:46 
15:07:46   Could not find a package configuration file provided by "ament_lint_auto"
15:07:46   with any of the following names:
15:07:46 
15:07:46     ament_lint_autoConfig.cmake
15:07:46     ament_lint_auto-config.cmake
15:07:46 
15:07:46   Add the installation prefix of "ament_lint_auto" to CMAKE_PREFIX_PATH or
15:07:46   set "ament_lint_auto_DIR" to a directory containing one of the above files.
15:07:46   If "ament_lint_auto" provides a separate development package or SDK, be
15:07:46   sure it has been installed.
```