### PR TITLE
Massive performance improvements and cleaner shutdown

### DIFF
--- a/include/transform.hpp
+++ b/include/transform.hpp
@@ -38,7 +38,7 @@ private:
   double offset_y;
 
 public:
-  explicit SlTransform(LDVersion version, bool to_right_hand = false);
+  explicit SlTransform(LDVersion version);
   Points2D Transform(const Points2D & data);
   ~SlTransform();
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,6 +49,11 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("laser_scan_publisher");
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr lidar_pub;
 
+  // default Set polling rate to 40Hz, this should be enough for most cases
+  double poll_rate_hz = node->declare_parameter("poll_rate_hz", 40.0);
+  rclcpp::Rate loop_rate(poll_rate_hz);
+  std::cout << "Lidar poll rate set to " << poll_rate_hz << " Hz"<< std::endl;
+
   LiPkg * pkg;
   std::string product;
   int32_t ver = 8;
@@ -84,9 +89,6 @@ int main(int argc, char ** argv)
     lidar_pub = node->create_publisher<sensor_msgs::msg::LaserScan>(
       "scan", rclcpp::QoS(rclcpp::SensorDataQoS())
     );
-
-    // Set polling rate to 40Hz, this should be enough for most cases
-    rclcpp::Rate loop_rate(40);
     
     while (rclcpp::ok() && !shutdown_requested.load()) {
       if (pkg->IsFrameReady()) {

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -27,7 +27,7 @@
   \param[out]  data
   \retval      Data after coordinate conversion
 */
-SlTransform::SlTransform(LDVersion version, bool to_right_hand)
+SlTransform::SlTransform(LDVersion version)
 {
   switch (version) {
     case LDVersion::LD_ZERO:


### PR DESCRIPTION
Tight while() loop in main() now uses rclpp::Rate to reduce CPU usage due to busy waiting.
Node now catches both SIGINT and TERM and passes off shutdown to handler.
CPU usage has gone from 100% of one core to around 1-3%.