### PR TITLE
Remove the unused parameter from the constructor of the SlTransform class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog for package ld08_driver
 1.1.2 (2025-04-02)
 ------------------
 * Removed the unused parameter from the constructor of the SlTransform class
-* Contributors: Pyo, Hyungyu Kim
+* Contributors: Hyungyu Kim
 
 1.1.1 (2025-03-27)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ld08_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.1.2 (2025-04-02)
+------------------
+* Removed the unused parameter from the constructor of the SlTransform class
+* Contributors: Pyo, Hyungyu Kim
+
 1.1.1 (2025-03-27)
 ------------------
 * Added the boost and libudev-dev dependency for release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,6 @@ find_package(Boost REQUIRED system)
 ################################################################################
 include_directories(
   include
-  ${catkin_INCLUDE_DIRS}
 )
 
 set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
@@ -39,7 +38,7 @@ set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
 file(GLOB  MAIN_SRC src/*.cpp)
 
 add_executable(ld08_driver  ${MAIN_SRC})
-target_link_libraries(ld08_driver pthread udev  ${catkin_LIBRARIES})
+target_link_libraries(ld08_driver pthread udev Boost)
 ament_target_dependencies(ld08_driver
   rclcpp
   std_msgs

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
 file(GLOB  MAIN_SRC src/*.cpp)
 
 add_executable(ld08_driver  ${MAIN_SRC})
-target_link_libraries(ld08_driver pthread udev Boost)
+target_link_libraries(ld08_driver pthread udev Boost::system)
 ament_target_dependencies(ld08_driver
   rclcpp
   std_msgs

--- a/include/transform.hpp
+++ b/include/transform.hpp
@@ -38,7 +38,7 @@ private:
   double offset_y;
 
 public:
-  explicit SlTransform(LDVersion version, bool to_right_hand = false);
+  explicit SlTransform(LDVersion version);
   Points2D Transform(const Points2D & data);
   ~SlTransform();
 };

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ld08_driver</name>
-  <version>1.1.1</version>
+  <version>1.1.2</version>
   <description>
     ROS package for LDS-02(LD08) Lidar.
     The Lidar sensor sends data to the Host controller for the Simultaneous Localization And Mapping(SLAM).

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -27,7 +27,7 @@
   \param[out]  data
   \retval      Data after coordinate conversion
 */
-SlTransform::SlTransform(LDVersion version, bool to_right_hand)
+SlTransform::SlTransform(LDVersion version)
 {
   switch (version) {
     case LDVersion::LD_ZERO:


### PR DESCRIPTION
### Description
Resolved build warning `warning: unused parameter ‘to_right_hand’ [-Wunused-parameter]`

### Change
Remove the unused parameter from the constructor of the SlTransform class