### PR TITLE
Make `/scan` topic frame id set flexibly and decrease lidar cpu usage.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,8 @@ Changelog for package ld08_driver
 1.1.3 (2025-04-11)
 ------------------
 * Support flexible configuration of the frame_id used when publishing the scan topic
-* Reduce CPU usage of the ld08 LiDAR node by adding sleep to its main loop
-* Contributors: Hyungyu Kim
+* Reduce CPU usage of the ld08 LiDAR node by adding sleep to its main loop, related PR(https://github.com/ROBOTIS-GIT/ld08_driver/pull/23)
+* Contributors: Hyungyu Kim, Xander Soldaat
 
 1.1.2 (2025-04-02)
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog for package ld08_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.1.3 (2025-04-11)
+------------------
+* Support flexible configuration of the frame_id used when publishing the scan topic
+* Reduce CPU usage of the ld08 LiDAR node by adding sleep to its main loop
+* Contributors: Hyungyu Kim
+
 1.1.2 (2025-04-02)
 ------------------
 * Removed the unused parameter from the constructor of the SlTransform class

--- a/include/lipkg.hpp
+++ b/include/lipkg.hpp
@@ -16,12 +16,16 @@
 
 #ifndef LIPKG_HPP_
 #define LIPKG_HPP_
+
 #include <stdint.h>
-#include <vector>
 #include <array>
+#include <string>
+#include <vector>
 #include <iostream>
+
 #include <sensor_msgs/msg/laser_scan.hpp>
 #include <rclcpp/rclcpp.hpp>
+
 #include "../include/pointdata.hpp"
 
 #define ANGLE_TO_RADIAN(angle) ((angle) * 3141.59 / 180000)

--- a/include/lipkg.hpp
+++ b/include/lipkg.hpp
@@ -92,6 +92,7 @@ public:
   const FrameData & GetFrameData(void) {mIsFrameReady = false; return mFrameData;}
   sensor_msgs::msg::LaserScan GetLaserScan() {return output;}
   void setStamp(rclcpp::Time timeStamp) {output.header.stamp = timeStamp;}
+  void setFrameId(std::string frame_id) {output.header.frame_id = frame_id;}
 
 private:
   uint16_t mTimestamp;

--- a/launch/ld08.launch.py
+++ b/launch/ld08.launch.py
@@ -19,14 +19,22 @@
 
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch.substitutions import LaunchConfiguration
 
 
 def generate_launch_description():
+
+    frame_id = LaunchConfiguration('frame_id', default='base_scan')
+    namespace = LaunchConfiguration('namespace', default='')
 
     return LaunchDescription([
         Node(
             package='ld08_driver',
             executable='ld08_driver',
             name='ld08_driver',
-            output='screen'),
+            output='screen',
+            parameters=[
+                {'frame_id': frame_id},
+                {'namespace': namespace},
+            ]),
     ])

--- a/launch/ld08.launch.py
+++ b/launch/ld08.launch.py
@@ -18,8 +18,8 @@
 
 
 from launch import LaunchDescription
-from launch_ros.actions import Node
 from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
 
 
 def generate_launch_description():

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ld08_driver</name>
-  <version>1.1.2</version>
+  <version>1.1.3</version>
   <description>
     ROS package for LDS-02(LD08) Lidar.
     The Lidar sensor sends data to the Host controller for the Simultaneous Localization And Mapping(SLAM).

--- a/src/lipkg.cpp
+++ b/src/lipkg.cpp
@@ -229,8 +229,6 @@ void LiPkg::ToLaserscan(std::vector<PointData> src)
 
   // Calculate the number of scanning points
   unsigned int beam_size = ceil((angle_max - angle_min) / angle_increment);
-  // output.header.stamp = rclcpp::Time::now();
-  output.header.frame_id = "base_scan";
   output.angle_min = angle_min;
   output.angle_max = angle_max;
   output.range_min = range_min;

--- a/src/lipkg.cpp
+++ b/src/lipkg.cpp
@@ -18,6 +18,7 @@
 #include <math.h>
 #include <algorithm>
 
+
 #define USE_SLBF
 
 #ifdef USE_SLBI

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,12 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("laser_scan_publisher");
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr lidar_pub;
 
+  std::string frame_id = node->get_parameter("frame_id").as_string();
+  std::string namespace = node->get_parameter("namespace").as_string();
+  if(namespace =! "") {
+    frame_id = namespace + "/" + frame_id;
+  }
+
   LiPkg * pkg;
   std::string product;
   int32_t ver = 8;
@@ -68,6 +74,7 @@ int main(int argc, char ** argv)
     while (rclcpp::ok()) {
       if (pkg->IsFrameReady()) {
         pkg->setStamp(node->now());
+        pkg->setFrameID(frame_id);
         lidar_pub->publish(pkg->GetLaserScan());
         pkg->ResetFrameReady();
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,11 +16,13 @@
 
 #include <stdio.h>
 #include <iostream>
+
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/laser_scan.hpp>
+
 #include "../include/cmd_interface_linux.hpp"
 #include "../include/lipkg.hpp"
 #include "../include/transform.hpp"
-#include <rclcpp/rclcpp.hpp>
-#include <sensor_msgs/msg/laser_scan.hpp>
 
 
 int main(int argc, char ** argv)
@@ -34,7 +36,7 @@ int main(int argc, char ** argv)
   node->declare_parameter<std::string>("namespace", "");
   std::string frame_id = node->get_parameter("frame_id").as_string();
   std::string name_space = node->get_parameter("namespace").as_string();
-  if(name_space != "") {
+  if (name_space != "") {
     frame_id = name_space + "/" + frame_id;
   }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,8 @@ int main(int argc, char ** argv)
   auto node = rclcpp::Node::make_shared("laser_scan_publisher");
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr lidar_pub;
 
+  node->declare_parameter<std::string>("frame_id", "base_scan");
+  node->declare_parameter<std::string>("namespace", "");
   std::string frame_id = node->get_parameter("frame_id").as_string();
   std::string name_space = node->get_parameter("namespace").as_string();
   if(name_space != "") {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@ int main(int argc, char ** argv)
   rclcpp::init(argc, argv);
   auto node = rclcpp::Node::make_shared("laser_scan_publisher");
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr lidar_pub;
+  rclcpp::Rate loop_rate(100.0);
 
   node->declare_parameter<std::string>("frame_id", "base_scan");
   node->declare_parameter<std::string>("namespace", "");
@@ -80,6 +81,7 @@ int main(int argc, char ** argv)
         lidar_pub->publish(pkg->GetLaserScan());
         pkg->ResetFrameReady();
       }
+      loop_rate.sleep();
     }
   } else {
     std::cout << "Can't find LDS-02" << product << std::endl;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,9 +30,9 @@ int main(int argc, char ** argv)
   rclcpp::Publisher<sensor_msgs::msg::LaserScan>::SharedPtr lidar_pub;
 
   std::string frame_id = node->get_parameter("frame_id").as_string();
-  std::string namespace = node->get_parameter("namespace").as_string();
-  if(namespace =! "") {
-    frame_id = namespace + "/" + frame_id;
+  std::string name_space = node->get_parameter("namespace").as_string();
+  if(name_space != "") {
+    frame_id = name_space + "/" + frame_id;
   }
 
   LiPkg * pkg;
@@ -74,7 +74,7 @@ int main(int argc, char ** argv)
     while (rclcpp::ok()) {
       if (pkg->IsFrameReady()) {
         pkg->setStamp(node->now());
-        pkg->setFrameID(frame_id);
+        pkg->setFrameId(frame_id);
         lidar_pub->publish(pkg->GetLaserScan());
         pkg->ResetFrameReady();
       }


### PR DESCRIPTION
## Change1
- Add parameters `frame_id`,`namespace`
  - Support dynamic frame configuration for topic publishing via namespace argument in multi-robot operation.
## Change2
- Add sleep to its main loop.
  - Reduce CPU usage of the ld08 LiDAR node
 
## Validation

- before

![Screenshot from 2025-04-11 13-38-45](https://github.com/user-attachments/assets/9674d2bc-e91d-4ac5-b580-750f3c28b89b)

![Screenshot from 2025-04-11 14-18-51](https://github.com/user-attachments/assets/85c7811f-d219-4396-ac88-d36dd959098b)

- after

![Screenshot from 2025-04-11 14-10-11](https://github.com/user-attachments/assets/966afaa1-91f5-4adb-960a-9e30e49b9803)

![Screenshot from 2025-04-11 14-17-08](https://github.com/user-attachments/assets/8525a246-cf1e-4f7b-ade6-b0925cdecb1a)

- Topic transmission was maintained without performance degradation, and CPU usage was reduced from 100% to 5%.