### PR TITLE
Deprecate ament_include_dependency usage in CMakeLists.txt 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package ld08_driver
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+1.1.4 (2025-05-28)
+------------------
+* Deprecate ament_include_dependency usage in CMakeLists.txt
+* Contributor: Hyungyu Kim
+
 1.1.3 (2025-04-11)
 ------------------
 * Support flexible configuration of the frame_id used when publishing the scan topic

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,15 @@ set(CMAKE_CXX_FLAGS "-std=c++17 ${CMAKE_CXX_FLAGS}")
 file(GLOB  MAIN_SRC src/*.cpp)
 
 add_executable(ld08_driver  ${MAIN_SRC})
-target_link_libraries(ld08_driver pthread udev Boost::system)
-ament_target_dependencies(ld08_driver
-  rclcpp
-  std_msgs
-  sensor_msgs
+target_link_libraries(ld08_driver
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  Boost::system
+  pthread
+  rclcpp::rclcpp
+  udev
 )
+
 
 ################################################################################
 # Install
@@ -60,8 +63,13 @@ install(
 ################################################################################
 # Macro for ament package
 ################################################################################
-ament_export_dependencies(rclcpp)
-ament_export_dependencies(std_msgs)
-ament_export_dependencies(sensor_msgs)
+ament_export_dependencies(
+  rclcpp
+  std_msgs
+  sensor_msgs
+  Boost::system
+  pthread
+  udev
+)
 ament_export_include_directories(include)
 ament_package()

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>ld08_driver</name>
-  <version>1.1.3</version>
+  <version>1.1.4</version>
   <description>
     ROS package for LDS-02(LD08) Lidar.
     The Lidar sensor sends data to the Host controller for the Simultaneous Localization And Mapping(SLAM).


### PR DESCRIPTION
## CHANGE
- Substitute ament_include_dependency to target_link_libraries & target_include_directories

## NOTE
- TEST build well in humble and rolling docker.
- TEST operating in humble.